### PR TITLE
Remove direct analysis calls in Terminal stream

### DIFF
--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -2722,11 +2722,9 @@ When responding, you will adopt the distinct voice(s) of the active advisor(s) a
     if (messages.length > 1 && !isLoading) {
       const lastMessage = messages[messages.length - 1];
       // Only analyze after Claude responses (assistant messages)
-      if (lastMessage.type === 'assistant') {
-        console.log('🔍 Triggering analysis after Claude response');
-        analyzeMetaphors(messages);
-        analyzeForQuestions(messages);
-      }
+        if (lastMessage.type === 'assistant') {
+          console.log('🔍 Triggering analysis after Claude response');
+        }
     }
   }, [messages, isLoading, metaphorsExpanded, questionsExpanded, openaiClient]);
 


### PR DESCRIPTION
## Summary
- clean up Terminal.jsx streaming loop
- remove leftover analysis function calls

## Testing
- `npm run lint` *(fails: no-unused-vars, etc.)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843046637ac832f8d90cb512f1da598