### PR TITLE
Fix: Prevent duplicate advisor names to resolve activation bug

### DIFF
--- a/src/components/AdvisorForm.jsx
+++ b/src/components/AdvisorForm.jsx
@@ -128,6 +128,15 @@ const AdvisorForm = ({ onSubmit, onCancel, initialName = '', existingAdvisors = 
       return;
     }
     
+    // Check for duplicate names
+    const isDuplicate = existingAdvisors.some(advisor => 
+      advisor.name.toLowerCase() === name.trim().toLowerCase()
+    );
+    if (isDuplicate) {
+      setError('An advisor with this name already exists. Please choose a different name.');
+      return;
+    }
+    
     if (description.trim()) {
       setError('Clear the description field before generating a new description');
       return;
@@ -237,6 +246,20 @@ const AdvisorForm = ({ onSubmit, onCancel, initialName = '', existingAdvisors = 
           </button>
           <button
             onClick={() => {
+              if (!name.trim()) {
+                setError('Please enter an advisor name');
+                return;
+              }
+              
+              // Check for duplicate names
+              const isDuplicate = existingAdvisors.some(advisor => 
+                advisor.name.toLowerCase() === name.trim().toLowerCase()
+              );
+              if (isDuplicate) {
+                setError('An advisor with this name already exists. Please choose a different name.');
+                return;
+              }
+              
               trackAdvisorCreated(name);
               onSubmit({ name, description, color: selectedColor });
             }}

--- a/src/components/EditAdvisorForm.jsx
+++ b/src/components/EditAdvisorForm.jsx
@@ -1,13 +1,31 @@
 import React, { useState } from 'react';
 import { ADVISOR_COLORS } from '../lib/advisorColors';
 
-const EditAdvisorForm = ({ advisor, onSubmit, onCancel }) => {
+const EditAdvisorForm = ({ advisor, onSubmit, onCancel, existingAdvisors = [] }) => {
   const [name, setName] = useState(advisor.name);
   const [description, setDescription] = useState(advisor.description);
   const [selectedColor, setSelectedColor] = useState(advisor.color || ADVISOR_COLORS[0]);
+  const [error, setError] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    
+    if (!name.trim()) {
+      setError('Please enter an advisor name');
+      return;
+    }
+    
+    // Check for duplicate names (but allow keeping the same name)
+    const isDuplicate = existingAdvisors.some(existingAdvisor => 
+      existingAdvisor.name.toLowerCase() === name.trim().toLowerCase() && 
+      existingAdvisor.name !== advisor.name
+    );
+    if (isDuplicate) {
+      setError('An advisor with this name already exists. Please choose a different name.');
+      return;
+    }
+    
+    setError('');
     onSubmit({ name, description, color: selectedColor });
   };
 
@@ -15,6 +33,9 @@ const EditAdvisorForm = ({ advisor, onSubmit, onCancel }) => {
     <div className="fixed inset-0 bg-white/70 dark:bg-black/50 flex items-center justify-center">
       <div className="bg-gray-100 p-6 rounded-lg border border-green-600 w-96 max-h-[80vh] overflow-y-auto overflow-x-hidden dark:bg-gray-900 dark:border-green-400">
         <h2 className="text-green-400 text-xl mb-4">Edit Advisor</h2>
+        {error && (
+          <div className="text-red-400 mb-4">{error}</div>
+        )}
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label className="block text-green-400 mb-2">Name:</label>

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -3857,8 +3857,23 @@ ${selectedText}
               initialName={suggestedAdvisorName}
               existingAdvisors={advisors}
               onSubmit={({ name, description, color }) => {
+                // Additional validation as backup
+                const trimmedName = name.trim();
+                if (!trimmedName) {
+                  console.error('Empty advisor name');
+                  return;
+                }
+                
+                const isDuplicate = advisors.some(advisor => 
+                  advisor.name.toLowerCase() === trimmedName.toLowerCase()
+                );
+                if (isDuplicate) {
+                  console.error('Duplicate advisor name detected');
+                  return;
+                }
+                
                 const newAdvisor = {
-                  name,
+                  name: trimmedName,
                   description,
                   color,
                   active: true
@@ -3877,10 +3892,28 @@ ${selectedText}
           {editingAdvisor && (
             <EditAdvisorForm
               advisor={editingAdvisor}
+              existingAdvisors={advisors}
               onSubmit={({ name, description, color }) => {
+                // Additional validation as backup
+                const trimmedName = name.trim();
+                if (!trimmedName) {
+                  console.error('Empty advisor name');
+                  return;
+                }
+                
+                // Check for duplicate names (but allow keeping the same name)
+                const isDuplicate = advisors.some(advisor => 
+                  advisor.name.toLowerCase() === trimmedName.toLowerCase() && 
+                  advisor.name !== editingAdvisor.name
+                );
+                if (isDuplicate) {
+                  console.error('Duplicate advisor name detected');
+                  return;
+                }
+                
                 setAdvisors(prev => prev.map(a => 
                   a.name === editingAdvisor.name 
-                    ? { ...a, name, description, color }
+                    ? { ...a, name: trimmedName, description, color }
                     : a
                 ));
                 setEditingAdvisor(null);


### PR DESCRIPTION
## Summary
- Fixes bug where activating one advisor would affect another advisor with the same name
- Adds comprehensive duplicate name validation to prevent the issue from occurring

## Root Cause
The `handleAdvisorClick` function used `a.name === advisor.name` to toggle advisor states. When multiple advisors had identical names, both would be affected simultaneously.

## Solution
Rather than modify the activation logic, this prevents duplicate names entirely:

### Changes Made
- **AdvisorForm.jsx**: Validates for duplicates on generate and submit with user-friendly error messages
- **EditAdvisorForm.jsx**: Allows keeping same name when editing but prevents changing to duplicate names
- **Terminal.jsx**: Backup validation in submission handlers with proper error handling

### Key Features
✅ Case-insensitive validation ("Carl Jung" vs "carl jung")  
✅ Whitespace trimming to prevent spacing tricks  
✅ Clear error messages in red text  
✅ Edit mode support (can keep same name, can't change to duplicate)  
✅ Multiple validation layers for reliability  

## Test Plan
- [x] Build succeeds without errors
- [x] Logic verification confirms all validation scenarios work correctly
- [x] Prevents exact duplicates, case variations, and whitespace tricks
- [x] Edit mode properly allows same name but blocks duplicates

🤖 Generated with [Claude Code](https://claude.ai/code)